### PR TITLE
FIX Warning auto created field

### DIFF
--- a/oc_lettings_site/settings.py
+++ b/oc_lettings_site/settings.py
@@ -70,6 +70,7 @@ DATABASES = {
     }
 }
 
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators


### PR DESCRIPTION
## ADD
- Setting variable to define a AutoField base model and avoid Django 3.2 warning